### PR TITLE
start at appveyor setup for windows testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ install:
   - conda env create -f environment.yml
   - activate matplotcheck-dev
   - python setup.py install
-  - pip install -r dev-requirements.txt --user
+  - pip install -r dev-requirements.txt
 
 test_script:
   - conda list

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@
 # https://github.com/geopandas/geopandas/blob/master/appveyor.yml
 # https://github.com/earthlab/earthpy/blob/master/appveyor.yml
 
-
 matrix:
   fast_finish: true     # immediately finish build once one of the jobs fails.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
-# Mostly adapted from geopandas
+# Adapted from geopandas and earthpy setup
 # https://github.com/geopandas/geopandas/blob/master/appveyor.yml
+# https://github.com/earthlab/earthpy/blob/master/appveyor.yml
 
 matrix:
   fast_finish: true     # immediately finish build once one of the jobs fails.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@
 # https://github.com/geopandas/geopandas/blob/master/appveyor.yml
 # https://github.com/earthlab/earthpy/blob/master/appveyor.yml
 
+
 matrix:
   fast_finish: true     # immediately finish build once one of the jobs fails.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,10 +29,11 @@ install:
   - conda config --add channels conda-forge
   - conda info -a
   - conda env create -f environment.yml
-  - activate matplotcheck-dev
+  - conda activate matplotcheck-dev
   - python setup.py install
   - pip install -r dev-requirements.txt --user
 
 test_script:
   - conda list
+  - conda info -a
   - pytest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ install:
   - conda config --add channels conda-forge
   - conda info -a
   - conda env create -f environment.yml
-  - conda activate matplotcheck-dev
+  - activate matplotcheck-dev
   - python setup.py install
   - pip install -r dev-requirements.txt --user
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
   - conda env create -f environment.yml
   - activate matplotcheck-dev
   - python setup.py install
-  - pip install -r dev-requirements.txt
+  - pip install -r dev-requirements.txt --user
 
 test_script:
   - conda list

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,37 @@
+# Mostly adapted from geopandas
+# https://github.com/geopandas/geopandas/blob/master/appveyor.yml
+
+matrix:
+  fast_finish: true     # immediately finish build once one of the jobs fails.
+
+environment:
+  matrix:
+    - PYTHON_VERSION: "3.6"
+      MINICONDA: C:\Miniconda36-x64
+
+build: false
+
+init:
+  - "ECHO %PYTHON_VERSION% %MINICONDA%"
+
+install:
+  # cancel older builds for the same PR
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
+
+  # set up environment
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda config --set always_yes yes --set show_channel_urls true --set changeps1 no
+  - conda update -q conda
+  - conda config --add channels conda-forge
+  - conda info -a
+  - conda env create -f environment.yml
+  - activate matplotcheck-dev
+  - python setup.py install
+  - pip install -r dev-requirements.txt
+
+test_script:
+  - conda list
+  - pytest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,4 +10,4 @@ codecov
 sphinx_gallery
 pre-commit
 setuptools==40.8.0
-
+pip==19.0.3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,8 +2,9 @@ bumpversion
 sphinx==2.0.0
 sphinx-autobuild==0.7.1
 sphinx_rtd_theme
-pytest>=3.1.0
-pytest-cov>=2.2.0
+pytest
+pytest-cov
+pytest-vcr
 m2r
 codecov
 sphinx_gallery

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,4 +10,4 @@ codecov
 sphinx_gallery
 pre-commit
 setuptools==40.8.0
-pip==18.1
+


### PR DESCRIPTION
This PR is a start at the appveyor setup. let's see what happens...

NOTES: 
* This warning: `WARNING: The conda.compat module is deprecated and will be removed in a future release.` is a known issue: it will be fixed in a new release of conda -- see
https://github.com/conda/conda/issues/8512
* currently the instructions call `activate matplotcheck-dev` but i believe the new version of conda requires `conda activate`