### PR TITLE
Update pre-commit config python version 3.6 -> 3.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
   rev: stable
   hooks:
   - id: black
-    language_version: python3.6
+    language_version: python3.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Fix Python version mismatch in pre-commit hook vs dev environment (@kysolvik, #31)
 * Adding cross platform builds to CI


### PR DESCRIPTION
Fixes error when using the dev environment with the current pre-commit hook. (#31) 

Also added change to CHANGELOG.

