### PR TITLE
testing interactive installation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
   - conda info -a
   - conda env create -f environment.yml
   - activate matplotcheck-dev
-  - python setup.py install
+  - pip install -e . --no-deps
   - pip install -r dev-requirements.txt
 
 test_script:


### PR DESCRIPTION
This should fix the issue with appveyor failing on ALL tests. Essentially by installing earthpy interactively with pip we can avoid dependency installs which is what was causing the issues with things breaking. 