### PR TITLE
Base Test Coverage and Test Organization

### DIFF
--- a/matplotcheck/base.py
+++ b/matplotcheck/base.py
@@ -15,7 +15,6 @@ import math
 from scipy import stats
 import pandas as pd
 import geopandas as gpd
-import datetime
 
 
 class InvalidPlotError(Exception):

--- a/matplotcheck/base.py
+++ b/matplotcheck/base.py
@@ -57,7 +57,8 @@ class PlotTester(object):
 
     def _is_scatter(self):
         """Boolean expressing if ax contains scatter points.
-        If plot contains scatter points as well as lines, functions will return true.
+        If plot contains scatter points as well as lines, functions will return
+        true.
 
         Returns
         -------
@@ -89,7 +90,8 @@ class PlotTester(object):
         Returns
         -------
         None :
-            Nothing if Plot matches `plot_type`, otherwise throws ``AssertionError``
+            Nothing if Plot matches `plot_type`, otherwise throws
+            ``AssertionError``
         """
         if plot_type:
             if plot_type == "scatter":
@@ -117,7 +119,8 @@ class PlotTester(object):
         Returns
         -------
         suptitle : string
-            Figure title of the Figure that the `ax` object is on. If figure title is ``None``, this is an empty string.
+            Figure title of the Figure that the `ax` object is on. If figure
+            title is ``None``, this is an empty string.
         title : string
             Title on the axes. If title is ``None``, this is an empty string.
         """
@@ -127,24 +130,28 @@ class PlotTester(object):
         return suptitle, self.ax.get_title()
 
     def assert_title_contains(self, lst, title_type="either"):
-        """Asserts title contains each string in lst. Whether we test the axes title or figure title
+        """Asserts title contains each string in lst. Whether we test the axes
+        title or figure title
             is described in title_type.
 
         Parameters
         ----------
         lst: list
-            List of strings to be searched for in title. strings must be lower case.
+            List of strings to be searched for in title. strings must be lower
+            case.
         title_type: string
             One of the following strings ["figure", "axes", "either"]
             `figure`: only the figure title (suptitle) will be tested
             'axes': only the axes title (suptitle) will be tested
-            'either': either the figure title or axes title will pass this assertion.
+            'either': either the figure title or axes title will pass this
+            assertion.
             The combined title will be tested.
 
         Returns
         -------
         None :
-            Nothing if every element of `lst` exists in title, otherwise throws ``AssertionError``
+            Nothing if every element of `lst` exists in title, otherwise throws
+            ``AssertionError``
         """
         suptitle, axtitle = self.get_titles()
         if title_type == "either":
@@ -178,7 +185,8 @@ class PlotTester(object):
         Returns
         -------
         caption : string
-            matplotlib.text.Text if text is found in bottom right, ``None`` if no text is found
+            matplotlib.text.Text if text is found in bottom right, ``None``
+            if no text is found
         """
         caption = None
         ax_position = self.ax.get_position()
@@ -197,10 +205,11 @@ class PlotTester(object):
         """Asserts that Axes ax contains strings as expected in strings_exp.
         strings_exp is a list of lists. Each internal list is a list of
         strings where at least one string must be in the caption, barring
-        capitalization. For example, ``assert_caption_contains([['A'], ['B'], ['C']])``
-        checks that all of ``'A'``, ``'B'``, and ``'C'`` exist in the caption.
-        Alternatively, ``assert_caption_contains([['A', 'B', 'C']])`` checks
-        that any one of ``'A'``, ``'B'``, and ``'C'`` exist in the caption.
+        capitalization. For example,
+        ``assert_caption_contains([['A'], ['B'], ['C']])`` checks that all of
+        ``'A'``, ``'B'``, and ``'C'`` exist in the caption. Alternatively,
+        ``assert_caption_contains([['A', 'B', 'C']])`` checks that any one of
+        ``'A'``, ``'B'``, and ``'C'`` exist in the caption.
 
         Parameters
         ----------
@@ -212,14 +221,15 @@ class PlotTester(object):
         Returns
         -------
         None :
-            Nothing if caption contains strings matching `strings_exp`, otherwise throws ``AssertionError``
+            Nothing if caption contains strings matching `strings_exp`,
+            otherwise throws ``AssertionError``
 
         Notes
         -----
             This function enforces that no found strings can overlap.
-            Once a string is found, it is removed from the caption so that another
-            string does not match on overlapping text. Therefore, in some cases,
-            the order of `strings_exp` does matter.
+            Once a string is found, it is removed from the caption so that
+            another string does not match on overlapping text. Therefore, in
+            some cases, the order of `strings_exp` does matter.
         """
         caption = self.get_caption()
         if strings_exp == None:
@@ -255,7 +265,8 @@ class PlotTester(object):
         Returns
         ----------
         None :
-            Nothing if axis lines are not displayed on plot. Otherwise throws ``AssertionError`` with message `m`
+            Nothing if axis lines are not displayed on plot. Otherwise throws
+            ``AssertionError`` with message `m`
         """
         flag = False
         # Case 1: check if axis have been turned off
@@ -292,7 +303,8 @@ class PlotTester(object):
         Returns
         ----------
         None :
-            Nothing if axis label contains strings in `lst`. Otherwise throws ``AssertionError``
+            Nothing if axis label contains strings in `lst`. Otherwise throws
+            ``AssertionError``
         """
         # Retrieve appropriate axis label, error if axis param is not x or y
         if axis == "x":
@@ -324,14 +336,16 @@ class PlotTester(object):
         Parameters
         ---------
         lims_expected : list of numbers (float or int)
-            List of length 2 containing expected min and max vals for axis limits
+            List of length 2 containing expected min and max vals for axis
+            limits
         axis : string
             From ['x','y'], which axis to be tested
 
         Returns
         ----------
         None :
-            Nothing if `lims_expected` matches the limits of ax, otherwise throws ``AssertionError``
+            Nothing if `lims_expected` matches the limits of ax, otherwise
+            throws ``AssertionError``
         """
         # Get axis limit values
         if axis == "x":
@@ -364,7 +378,8 @@ class PlotTester(object):
         Returns
         ----------
         None :
-            Nothing if axis limits fall within `lims_range`, otherwise throws ``AssertionError``
+            Nothing if axis limits fall within `lims_range`, otherwise throws
+            ``AssertionError``
         """
         # Get ax axis limits
         if axis == "x":
@@ -395,7 +410,8 @@ class PlotTester(object):
         Returns
         ----------
         None :
-            Nothing if limits are equal, otherwise throws ``AssertionError`` with message `m`
+            Nothing if limits are equal, otherwise throws ``AssertionError``
+            with message `m`
         """
         xlims = self.ax.get_xlim()
         ylims = self.ax.get_ylim()
@@ -425,7 +441,8 @@ class PlotTester(object):
         Returns
         -------
         None :
-            Nothing if legend titles contain expected text, otherwise throws ``AssertionError``
+            Nothing if legend titles contain expected text, otherwise throws
+            ``AssertionError``
         """
         legends = self.get_legends()
 
@@ -463,7 +480,8 @@ class PlotTester(object):
         Returns
         -------
         None :
-            Nothing if legend labeles match `labels_exp`, otherwise throws ``AssertionError``
+            Nothing if legend labeles match `labels_exp`, otherwise throws
+            ``AssertionError``
 
         Notes
         -----
@@ -504,7 +522,8 @@ class PlotTester(object):
         Returns
         -------
         None :
-            Nothing if legend does not overlay plot window. Otherwise throws ``AssertionError`` with message `m`
+            Nothing if legend does not overlay plot window. Otherwise throws
+            ``AssertionError`` with message `m`
         """
         # RendererBase() is needed to get extent, otherwise raises an error
         plot_extent = self.ax.get_window_extent(RendererBase()).get_points()
@@ -553,7 +572,8 @@ class PlotTester(object):
         Returns
         -------
         None :
-            Nothing if no legends overlap, otherwise throws ``AssertionError`` with message `m`
+            Nothing if no legends overlap, otherwise throws ``AssertionError``
+            with message `m`
         """
         legends = self.get_legends()
         n = len(legends)
@@ -574,21 +594,24 @@ class PlotTester(object):
     """ BASIC PLOT DATA FUNCTIONS """
 
     def get_xy(self, points_only=False, xtime=False):
-        """Returns a pandas dataframe with columns "x" and "y" holding the x and y coords on Axes `ax`
+        """Returns a pandas dataframe with columns "x" and "y" holding the x
+        and y coords on Axes `ax`
 
         Parameters
         ----------
         ax : matplotlib.axes.Axes
             Matplotlib Axes object to be tested
         points_only : boolean
-            Set ``True`` to check only points, set ``False`` tp check all data on plot.
+            Set ``True`` to check only points, set ``False`` tp check all data
+            on plot.
         xtime : boolean
             Set equal to True if the x axis of the plot contains datetime values
 
         Returns
         -------
         df : pandas.DataFrame
-            Pandas dataframe with columns "x" and "y" containing the x and y coords of each point on Axes `ax`
+            Pandas dataframe with columns "x" and "y" containing the x and y
+            coords of each point on Axes `ax`
         """
         if points_only:
             xy_coords = [
@@ -639,26 +662,30 @@ class PlotTester(object):
         tolerence=0,
         m="Incorrect data values",
     ):
-        """Asserts that the x and y data of Axes `ax` matches `xy_expected` with error message `m`.
-        If ``xy_expected = None``, assertion is passed.
+        """Asserts that the x and y data of Axes `ax` matches `xy_expected`
+        with error message `m`. If ``xy_expected = None``, assertion is passed.
 
         Parameters
         ----------
         xy_expected : pandas or geopandas dataframe
-            (Required) DataFrame contains data expected to be on the plot (axis object)
+            (Required) DataFrame contains data expected to be on the plot
+            (axis object)
         xcol : string
-            (Required for non geopandas objects) Title of column in `xy_expected` containing values along `x_axis`.
+            (Required for non geopandas objects) Title of column in
+            `xy_expected` containing values along `x_axis`.
             If `xy_expected` contains this data in 'geometry', set to ``None``.
         ycol : String
-            (Required for non geopandas objects) The y column name of xy_expected which represents values along
-            the`y_axis` in a plot.
+            (Required for non geopandas objects) The y column name of
+            xy_expected which represents values along the`y_axis` in a plot.
             If `xy_expected` contains this data in 'geometry' set to ``None``.
         points_only : boolean,
-            Set ``True`` to check only points, set ``False`` tp check all data on plot.
+            Set ``True`` to check only points, set ``False`` tp check all data
+            on plot.
         xtime : boolean
-            Set ``True`` if the a-axis contains datetime values. Matplotlib converts
-            datetime objects to seconds? This parameter will ensure the provided
-            x col values are converted if they are datetime elements.
+            Set ``True`` if the a-axis contains datetime values. Matplotlib
+            converts datetime objects to seconds? This parameter will ensure
+            the provided x col values are converted if they are datetime
+            elements.
         xlabels : boolean
             Set ``True`` if using x axis labels rather than x data. Instead of
             comparing numbers in the x-column to expected, compares numbers in x
@@ -675,7 +702,8 @@ class PlotTester(object):
         Returns
         -------
         None :
-            Nothing if no legends overlap, otherwise throws ``AssertionError`` with message `m`
+            Nothing if no legends overlap, otherwise throws ``AssertionError``
+            with message `m`
         """
         if xy_expected is None:
             return
@@ -739,7 +767,8 @@ class PlotTester(object):
         Returns
         -------
         None :
-            Nothing if no legends overlap, otherwise throws ``AssertionError`` with message `m`
+            Nothing if no legends overlap, otherwise throws ``AssertionError``
+            with message `m`
 
         Notes
         -----
@@ -765,7 +794,8 @@ class PlotTester(object):
     ### LINE TESTS/HELPER FUNCTIONS ###
 
     def get_slope_yintercept(self, path_verts):
-        """Returns the y-intercept of line based on the average slope of the line
+        """Returns the y-intercept of line based on the average slope of the
+        line
 
         Parameters
         ----------
@@ -795,7 +825,9 @@ class PlotTester(object):
         m="Expected line not displayed",
         m2="Line does not cover data set",
     ):
-        """Asserts that there exists a line on Axes `ax` with slope `slope_exp` and y-intercept `intercept_exp` and goes at least from x coordinate `min_val` to x coordinate `max_val`
+        """Asserts that there exists a line on Axes `ax` with slope `slope_exp`
+        and y-intercept `intercept_exp` and goes at least from x coordinate
+        `min_val` to x coordinate `max_val`
 
         Parameters
         ----------
@@ -808,12 +840,14 @@ class PlotTester(object):
         m : string
             If line does not exist, `m` is displayed as the error message.
         m2 : string
-            If line exists but does not cover dataset, `m2` is displayed as the error message.
+            If line exists but does not cover dataset, `m2` is displayed as the
+            error message.
 
         Returns
         -------
         None :
-            Nothing if line exists and covers dataset, otherwise throws ``AssertionError`` with message `m` or `m2`
+            Nothing if line exists and covers dataset, otherwise throws
+            ``AssertionError`` with message `m` or `m2`
         """
         flag_exist, flag_length = False, False
         xy = self.get_xy(points_only=True)
@@ -842,12 +876,14 @@ class PlotTester(object):
         Parameters
         ----------
         line_types : list of strings
-            Acceptable strings in line_types are as follows ``['regression', 'onetoone']``.
+            Acceptable strings in line_types are as follows
+            ``['regression', 'onetoone']``.
 
         Returns
         -------
         None :
-            Nothing if each line of type in `line_types` exists on `ax`, otherwise throws ``AssertionError``.
+            Nothing if each line of type in `line_types` exists on `ax`,
+            otherwise throws ``AssertionError``.
 
         Notes
         -----
@@ -891,7 +927,8 @@ class PlotTester(object):
         Returns
         -------
         None :
-            Nothing if number of bins of type `which_bins` is at least `n`, otherwise throws ``AssertionError``.
+            Nothing if number of bins of type `which_bins` is at least `n`,
+            otherwise throws ``AssertionError``.
         """
         x_data = self.get_xy(xtime=False)["x"]
         if which_bins == "negative":

--- a/matplotcheck/base.py
+++ b/matplotcheck/base.py
@@ -131,8 +131,7 @@ class PlotTester(object):
 
     def assert_title_contains(self, lst, title_type="either"):
         """Asserts title contains each string in lst. Whether we test the axes
-        title or figure title
-            is described in title_type.
+        title or figure title is described in title_type.
 
         Parameters
         ----------
@@ -602,12 +601,7 @@ class PlotTester(object):
         ax : matplotlib.axes.Axes
             Matplotlib Axes object to be tested
         points_only : boolean
-<<<<<<< HEAD
-            Set ``True`` to check only points, set ``False`` tp check all data
-            on plot.
-=======
             Set ``True`` to check only points, set ``False`` to check all data on plot.
->>>>>>> master
         xtime : boolean
             Set equal to True if the x axis of the plot contains datetime values
 

--- a/matplotcheck/base.py
+++ b/matplotcheck/base.py
@@ -663,7 +663,9 @@ class PlotTester(object):
             datetime objects to seconds? This parameter will ensure the provided
             x col values are converted if they are datetime elements.
         xlabels : boolean
-            Set ``True`` if using x axis labels rather than x data.
+            Set ``True`` if using x axis labels rather than x data. Instead of
+            comparing numbers in the x-column to expected, compares numbers in x
+            labels to expected.
         tolerence : float
             Measure of relative error allowed.
             For example: Given a tolerance ``tolerence=0.1``, an expected value
@@ -698,7 +700,7 @@ class PlotTester(object):
             xcol, ycol = "x", "y"
 
         if xlabels:
-            self.assert_xlabel_ydata(xy_expected, xcol=xcol, ycol=ycol)
+            self.assert_xlabel_ydata(xy_expected, xcol=xcol, ycol=ycol, m=m)
             return
         xy_data = self.get_xy(points_only=points_only, xtime=xtime)
 

--- a/matplotcheck/base.py
+++ b/matplotcheck/base.py
@@ -15,6 +15,9 @@ import math
 from scipy import stats
 import pandas as pd
 import geopandas as gpd
+import datetime
+
+import pdb
 
 
 class InvalidPlotError(Exception):
@@ -699,6 +702,23 @@ class PlotTester(object):
                 xy_data.sort_values(by="x"),
                 xy_expected.sort_values(by=xcol),
             )
+
+            if isinstance(xy_data["x"][0], datetime.datetime):
+                pdb.set_trace()
+                for i, t in enumerate(xy_data["x"]):
+                    t = datetime.datetime(
+                        year=(t.year + 1970),
+                        month=t.month,
+                        day=t.day,
+                        hour=t.hour,
+                        minute=t.minute,
+                        second=t.second,
+                        microsecond=t.microsecond,
+                        # tzinfo=t.tzinfo,
+                    )
+                    xy_data["x"][i] = t
+                pdb.set_trace()
+
             if tolerence > 0:
                 if xtime:
                     raise ValueError(

--- a/matplotcheck/base.py
+++ b/matplotcheck/base.py
@@ -17,8 +17,6 @@ import pandas as pd
 import geopandas as gpd
 import datetime
 
-import pdb
-
 
 class InvalidPlotError(Exception):
     pass

--- a/matplotcheck/base.py
+++ b/matplotcheck/base.py
@@ -679,7 +679,7 @@ class PlotTester(object):
             Nothing if no legends overlap, otherwise throws ``AssertionError`` with message `m`
         """
         if xy_expected is None:
-            pass
+            return
         elif not isinstance(xy_expected, pd.DataFrame):
             raise ValueError(
                 "xy_expected must be of type: pandas dataframe or Geopandas Dataframe"

--- a/matplotcheck/base.py
+++ b/matplotcheck/base.py
@@ -711,15 +711,6 @@ class PlotTester(object):
         if tolerence > 0:
             if xtime:
                 raise ValueError("tolerance must be 0 with datetime on x-axis")
-            """
-            for i in range(100):
-                np.testing.assert_allclose(
-                    xy_data.iloc[0, 0:i], xy_expected.iloc[0, 0:i], rtol=tolerence, err_msg=m
-                )
-                np.testing.assert_allclose(
-                    xy_data.iloc[1, 0:i], xy_expected.iloc[1, 0:i], rtol=tolerence, err_msg=m
-                )
-            """
             np.testing.assert_allclose(
                 xy_data["x"], xy_expected[xcol], rtol=tolerence, err_msg=m
             )

--- a/matplotcheck/base.py
+++ b/matplotcheck/base.py
@@ -711,12 +711,22 @@ class PlotTester(object):
         if tolerence > 0:
             if xtime:
                 raise ValueError("tolerance must be 0 with datetime on x-axis")
+            """
+            for i in range(100):
+                np.testing.assert_allclose(
+                    xy_data.iloc[0, 0:i], xy_expected.iloc[0, 0:i], rtol=tolerence, err_msg=m
+                )
+                np.testing.assert_allclose(
+                    xy_data.iloc[1, 0:i], xy_expected.iloc[1, 0:i], rtol=tolerence, err_msg=m
+                )
+            """
             np.testing.assert_allclose(
                 xy_data["x"], xy_expected[xcol], rtol=tolerence, err_msg=m
             )
             np.testing.assert_allclose(
                 xy_data["y"], xy_expected[ycol], rtol=tolerence, err_msg=m
             )
+
         else:
             assert np.array_equal(xy_data["x"], xy_expected[xcol]), m
             assert np.array_equal(xy_data["y"], xy_expected[ycol]), m

--- a/matplotcheck/tests/conftest.py
+++ b/matplotcheck/tests/conftest.py
@@ -44,6 +44,7 @@ def pd_gdf():
 
 @pytest.fixture
 def pd_xlabels():
+    """Create a DataFrame which uses the column labels as x-data."""
     df = pd.DataFrame({"B": bp.random.randint(0, 100, size=100)})
 
 
@@ -129,6 +130,7 @@ def pt_time_line_plt(pd_df_timeseries):
 
 @pytest.fixture
 def pt_geo_plot(pd_gdf):
+    """Create a geo plot for testing"""
     fig, ax = plt.subplots()
 
     pd_gdf.plot(ax=ax)

--- a/matplotcheck/tests/conftest.py
+++ b/matplotcheck/tests/conftest.py
@@ -1,9 +1,12 @@
 """Pytest fixtures for matplotcheck tests"""
 import pytest
 import pandas as pd
+import geopandas as gpd
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotcheck.base import PlotTester
+
+import pdb
 
 
 @pytest.fixture
@@ -23,6 +26,27 @@ def pd_df_timeseries():
             "A": np.random.randint(0, 100, size=100),
         }
     )
+
+
+@pytest.fixture
+def pd_gdf():
+    """Create a geopandas GeoDataFrame for testing"""
+    df = pd.DataFrame(
+        {
+            "lat": np.random.randint(-85, 85, size=100),
+            "lon": np.random.randint(-180, 180, size=100),
+        }
+    )
+    gdf = gpd.GeoDataFrame(
+        {"A": np.arange(100)}, geometry=gpd.points_from_xy(df.lon, df.lat)
+    )
+
+    return gdf
+
+
+@pytest.fixture
+def pd_xlabels():
+    df = pd.DataFrame({"B": bp.random.randint(0, 100, size=100)})
 
 
 @pytest.fixture
@@ -99,6 +123,20 @@ def pt_time_line_plt(pd_df_timeseries):
     fig, ax = plt.subplots()
 
     pd_df_timeseries.plot("time", "A", kind="line", ax=ax)
+
+    axis = plt.gca()
+
+    return PlotTester(axis)
+
+
+@pytest.fixture
+def pt_geo_plot(pd_gdf):
+    fig, ax = plt.subplots()
+
+    pd_gdf.plot(ax=ax)
+    ax.set_title("My Plot Title", fontsize=30)
+    ax.set_xlabel("x label")
+    ax.set_ylabel("y label")
 
     axis = plt.gca()
 

--- a/matplotcheck/tests/conftest.py
+++ b/matplotcheck/tests/conftest.py
@@ -6,8 +6,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotcheck.base import PlotTester
 
-import pdb
-
 
 @pytest.fixture
 def pd_df():

--- a/matplotcheck/tests/test_base.py
+++ b/matplotcheck/tests/test_base.py
@@ -1,10 +1,6 @@
 """Tests for the base module"""
 import pytest
 import matplotlib.pyplot as plt
-import numpy as np
-import random
-
-import pdb
 
 
 def test_line_plot(pt_line_plt):
@@ -55,78 +51,9 @@ def test_options(pt_line_plt):
     plt.close()
 
 
-def test_correct_title(pt_line_plt):
-    """Check that the correct plot title is grabbed from the axis object.
-    Note that get_titles maintains case."""
-
-    assert "Plot Title" in pt_line_plt.get_titles()[1]
-    plt.close()
-
-
-"""DATACHECK TESTS"""
-
-
-def test_assert_xydata_scatter(pt_scatter_plt, pd_df):
-    """Checks points in scatter plot against expected data"""
-    pt_scatter_plt.assert_xydata(pd_df, xcol="A", ycol="B")
-    plt.close()
-
-
-def test_assert_xydata_tolerance(pt_scatter_plt, pd_df):
-
-    for i in range(len(pd_df["A"])):
-        pd_df["A"][i] = pd_df["A"][i] + (np.floor(pd_df["A"][i] * 0.25))
-        pd_df["B"][i] = pd_df["B"][i] + (np.floor(pd_df["B"][i] * 0.25))
-    pt_scatter_plt.assert_xydata(pd_df, xcol="A", ycol="B", tolerence=0.5)
-    plt.close()
-
-
-def test_assert_xydata_tolerance_fail(pt_scatter_plt, pd_df):
-    pd_df["A"][1] = pd_df["A"][1] * 2
-    with pytest.raises(AssertionError, match="Incorrect data values"):
-        pt_scatter_plt.assert_xydata(pd_df, xcol="A", ycol="B", tolerence=0.1)
-    plt.close()
-
-
-def test_assert_xydata_changed_data(pt_scatter_plt, pd_df):
-    """assert_xydata should fail when we change the data"""
-    pd_df["B"][1] += 5
-    with pytest.raises(AssertionError, match="Incorrect data values"):
-        pt_scatter_plt.assert_xydata(pd_df, xcol="A", ycol="B")
-    plt.close()
-
-
-def test_assert_xydata_scatter_points_only(pt_scatter_plt, pd_df):
-    """Checks points in scatter plot against expected data"""
-    pt_scatter_plt.assert_xydata(pd_df, xcol="A", ycol="B", points_only=True)
-    plt.close()
-
-
-def test_assert_xydata_changed_data_points_only(pt_scatter_plt, pd_df):
-    """assert_xydata should fail when we change the data"""
-    pd_df["B"][1] += 5
-    with pytest.raises(AssertionError, match="Incorrect data values"):
-        pt_scatter_plt.assert_xydata(
-            pd_df, xcol="A", ycol="B", points_only=True
-        )
-    plt.close()
-
-
+"""
+Test fo geopandas. Commenting out until later.
 def test_assert_xydata_geo(pd_gdf, pt_geo_plot):
     pt_geo_plot.assert_xydata(pd_gdf)
     plt.close()
-
-
-'''
-def test_assert_xydata_timeseries(pt_time_line_plt, pd_df_timeseries):
-    """Commenting this out for now as this requires a time series data object
-    this is failing because the time data needs to be in seconds like how
-    mpl saves it. """
-    pt_time_line_plt.assert_xydata(pd_df_timeseries, xcol='time', ycol='A', xtime=True)
-'''
-
-
-def test_assert_xydata_xlabel(pt_bar_plt, pd_df):
-    pd_df["A"] = pd_df["A"].apply(str)
-    pt_bar_plt.assert_xlabel_ydata(pd_df, xcol="A", ycol="B")
-    plt.close()
+"""

--- a/matplotcheck/tests/test_base.py
+++ b/matplotcheck/tests/test_base.py
@@ -72,8 +72,9 @@ def test_assert_xydata_scatter(pt_scatter_plt, pd_df):
     plt.close()
 
 
+"""
+commenting out for now
 def test_assert_xydata_tolerance(pt_scatter_plt, pd_df):
-    pdb.set_trace()
     for i in range(len(pd_df["A"])):
         pd_df["A"][i] = pd_df["A"][i] + (
             random.choice([-1, 0, 1]) * np.floor(pd_df["A"][i] * 0.5)
@@ -86,10 +87,10 @@ def test_assert_xydata_tolerance(pt_scatter_plt, pd_df):
 
 
 def test_assert_xydata_tolerance_fail(pt_scatter_plt, pd_df):
-    pdb.set_trace()
     pd_df["A"][1] = pd_df["A"][1] * 2
     pt_scatter_plt.assert_xydata(pd_df, xcol="A", ycol="B", tolerence=0.1)
     plt.close()
+"""
 
 
 def test_assert_xydata_changed_data(pt_scatter_plt, pd_df):

--- a/matplotcheck/tests/test_base.py
+++ b/matplotcheck/tests/test_base.py
@@ -8,9 +8,9 @@ def test_line_plot(pt_line_plt):
     scatter."""
     pt_line_plt.assert_plot_type("line")
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match="Plot is not of type bar"):
         pt_line_plt.assert_plot_type("bar")
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match="Plot is not of type scatter"):
         pt_line_plt.assert_plot_type("scatter")
     plt.close()
 
@@ -20,9 +20,9 @@ def test_scatter_plot(pt_scatter_plt):
     line."""
     pt_scatter_plt.assert_plot_type("scatter")
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match="Plot is not of type bar"):
         pt_scatter_plt.assert_plot_type("bar")
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match="Plot is not of type line"):
         pt_scatter_plt.assert_plot_type("line")
     plt.close()
 
@@ -32,16 +32,16 @@ def test_bar_plot(pt_bar_plt):
     line."""
     pt_bar_plt.assert_plot_type("bar")
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match="Plot is not of type scatter"):
         pt_bar_plt.assert_plot_type("scatter")
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match="Plot is not of type line"):
         pt_bar_plt.assert_plot_type("line")
     plt.close()
 
 
 def test_options(pt_line_plt):
-    """Test that a ValueError is raised if an incorrect plot type is provided.
-    Should this test be unique of within a suite of tests?"""
+    """Test that a ValueError is raised if an incorrect plot type is
+    provided."""
 
     with pytest.raises(
         ValueError,
@@ -49,11 +49,3 @@ def test_options(pt_line_plt):
     ):
         pt_line_plt.assert_plot_type("foo")
     plt.close()
-
-
-"""
-Test fo geopandas. Commenting out until later.
-def test_assert_xydata_geo(pd_gdf, pt_geo_plot):
-    pt_geo_plot.assert_xydata(pd_gdf)
-    plt.close()
-"""

--- a/matplotcheck/tests/test_base.py
+++ b/matplotcheck/tests/test_base.py
@@ -1,6 +1,10 @@
 """Tests for the base module"""
 import pytest
 import matplotlib.pyplot as plt
+import numpy as np
+import random
+
+import pdb
 
 
 def test_line_plot(pt_line_plt):
@@ -68,6 +72,26 @@ def test_assert_xydata_scatter(pt_scatter_plt, pd_df):
     plt.close()
 
 
+def test_assert_xydata_tolerance(pt_scatter_plt, pd_df):
+    pdb.set_trace()
+    for i in range(len(pd_df["A"])):
+        pd_df["A"][i] = pd_df["A"][i] + (
+            random.choice([-1, 0, 1]) * np.floor(pd_df["A"][i] * 0.5)
+        )
+        pd_df["B"][i] = pd_df["B"][i] + (
+            random.choice([-1, 0, 1]) * np.floor(pd_df["B"][i] * 0.5)
+        )
+    pt_scatter_plt.assert_xydata(pd_df, xcol="A", ycol="B", tolerence=0.5)
+    plt.close()
+
+
+def test_assert_xydata_tolerance_fail(pt_scatter_plt, pd_df):
+    pdb.set_trace()
+    pd_df["A"][1] = pd_df["A"][1] * 2
+    pt_scatter_plt.assert_xydata(pd_df, xcol="A", ycol="B", tolerence=0.1)
+    plt.close()
+
+
 def test_assert_xydata_changed_data(pt_scatter_plt, pd_df):
     """assert_xydata should fail when we change the data"""
     pd_df["B"][1] += 5
@@ -89,6 +113,11 @@ def test_assert_xydata_changed_data_points_only(pt_scatter_plt, pd_df):
         pt_scatter_plt.assert_xydata(
             pd_df, xcol="A", ycol="B", points_only=True
         )
+    plt.close()
+
+
+def test_assert_xydata_geo(pd_gdf, pt_geo_plot):
+    pt_geo_plot.assert_xydata(pd_gdf)
     plt.close()
 
 

--- a/matplotcheck/tests/test_base.py
+++ b/matplotcheck/tests/test_base.py
@@ -72,25 +72,20 @@ def test_assert_xydata_scatter(pt_scatter_plt, pd_df):
     plt.close()
 
 
-"""
-commenting out for now
 def test_assert_xydata_tolerance(pt_scatter_plt, pd_df):
+
     for i in range(len(pd_df["A"])):
-        pd_df["A"][i] = pd_df["A"][i] + (
-            random.choice([-1, 0, 1]) * np.floor(pd_df["A"][i] * 0.5)
-        )
-        pd_df["B"][i] = pd_df["B"][i] + (
-            random.choice([-1, 0, 1]) * np.floor(pd_df["B"][i] * 0.5)
-        )
+        pd_df["A"][i] = pd_df["A"][i] + (np.floor(pd_df["A"][i] * 0.25))
+        pd_df["B"][i] = pd_df["B"][i] + (np.floor(pd_df["B"][i] * 0.25))
     pt_scatter_plt.assert_xydata(pd_df, xcol="A", ycol="B", tolerence=0.5)
     plt.close()
 
 
 def test_assert_xydata_tolerance_fail(pt_scatter_plt, pd_df):
     pd_df["A"][1] = pd_df["A"][1] * 2
-    pt_scatter_plt.assert_xydata(pd_df, xcol="A", ycol="B", tolerence=0.1)
+    with pytest.raises(AssertionError, match="Incorrect data values"):
+        pt_scatter_plt.assert_xydata(pd_df, xcol="A", ycol="B", tolerence=0.1)
     plt.close()
-"""
 
 
 def test_assert_xydata_changed_data(pt_scatter_plt, pd_df):

--- a/matplotcheck/tests/test_base.py
+++ b/matplotcheck/tests/test_base.py
@@ -68,7 +68,7 @@ def test_assert_xydata_scatter(pt_scatter_plt, pd_df):
     plt.close()
 
 
-def test_assert_xydata_scatter(pt_scatter_plt, pd_df):
+def test_assert_xydata_changed_data(pt_scatter_plt, pd_df):
     """assert_xydata should fail when we change the data"""
     pd_df["B"][1] += 5
     with pytest.raises(AssertionError, match="Incorrect data values"):
@@ -76,13 +76,29 @@ def test_assert_xydata_scatter(pt_scatter_plt, pd_df):
     plt.close()
 
 
-# def test_assert_xydata_timeseries(pt_time_line_plt, pd_df_timeseries):
-#   """Commenting this out for now as this requires a time series data object
-#   this is failing because the time data needs to be in seconds like how
-#   mpl saves it. """
-#     pt_time_line_plt.assert_xydata(pd_df_timeseries,
-#                                    xcol='time', ycol='A',
-#                                    xtime=True)
+def test_assert_xydata_scatter_points_only(pt_scatter_plt, pd_df):
+    """Checks points in scatter plot against expected data"""
+    pt_scatter_plt.assert_xydata(pd_df, xcol="A", ycol="B", points_only=True)
+    plt.close()
+
+
+def test_assert_xydata_changed_data_points_only(pt_scatter_plt, pd_df):
+    """assert_xydata should fail when we change the data"""
+    pd_df["B"][1] += 5
+    with pytest.raises(AssertionError, match="Incorrect data values"):
+        pt_scatter_plt.assert_xydata(
+            pd_df, xcol="A", ycol="B", points_only=True
+        )
+    plt.close()
+
+
+'''
+def test_assert_xydata_timeseries(pt_time_line_plt, pd_df_timeseries):
+    """Commenting this out for now as this requires a time series data object
+    this is failing because the time data needs to be in seconds like how
+    mpl saves it. """
+    pt_time_line_plt.assert_xydata(pd_df_timeseries, xcol='time', ycol='A', xtime=True)
+'''
 
 
 def test_assert_xydata_xlabel(pt_bar_plt, pd_df):

--- a/matplotcheck/tests/test_base_axis.py
+++ b/matplotcheck/tests/test_base_axis.py
@@ -107,13 +107,13 @@ def test_axis_label_contains_bad_text(pt_line_plt):
     plt.close()
 
 
-def test_axis_label_contains_expect_none(pt_line_plt):
+def test_axis_label_contains_expect_none(pt_multi_line_plt):
     """Check assert_axis_label_contains passes when expected text is blank"""
     pt_multi_line_plt.assert_axis_label_contains(axis="x", lst=None)
     plt.close()
 
 
-def test_axis_label_contains_expect_none(pt_multi_line_plt):
+def test_axis_label_contains_no_label(pt_multi_line_plt):
     """Check assert_axis_label_contains fails when there is no axis label"""
     with pytest.raises(
         AssertionError, match="Expected x axis label is not displayed"

--- a/matplotcheck/tests/test_base_data.py
+++ b/matplotcheck/tests/test_base_data.py
@@ -1,0 +1,80 @@
+"""Tests for the base module -- Data"""
+import pytest
+import matplotlib.pyplot as plt
+import numpy as np
+import random
+
+
+"""DATACHECK TESTS"""
+
+
+def test_assert_xydata_scatter(pt_scatter_plt, pd_df):
+    """Checks points in scatter plot against expected data"""
+    pt_scatter_plt.assert_xydata(pd_df, xcol="A", ycol="B")
+    plt.close()
+
+
+def test_assert_xydata_tolerance(pt_scatter_plt, pd_df):
+    """Checks that slightly altered data still passes with an appropriate tolerance"""
+    for i in range(len(pd_df["A"])):
+        pd_df["A"][i] = pd_df["A"][i] + (np.floor(pd_df["A"][i] * 0.25))
+        pd_df["B"][i] = pd_df["B"][i] + (np.floor(pd_df["B"][i] * 0.25))
+    pt_scatter_plt.assert_xydata(pd_df, xcol="A", ycol="B", tolerence=0.5)
+    plt.close()
+
+
+def test_assert_xydata_tolerance_fail(pt_scatter_plt, pd_df):
+    """Checks that data altered beyond the tolerance throws an assertion."""
+    pd_df["A"][1] = pd_df["A"][1] * 2
+    with pytest.raises(AssertionError, match="Incorrect data values"):
+        pt_scatter_plt.assert_xydata(pd_df, xcol="A", ycol="B", tolerence=0.1)
+    plt.close()
+
+
+def test_assert_xydata_changed_data(pt_scatter_plt, pd_df):
+    """assert_xydata should fail when we change the data"""
+    pd_df["B"][1] += 5
+    with pytest.raises(AssertionError, match="Incorrect data values"):
+        pt_scatter_plt.assert_xydata(pd_df, xcol="A", ycol="B")
+    plt.close()
+
+
+def test_assert_xydata_scatter_points_only(pt_scatter_plt, pd_df):
+    """Checks points in scatter plot against expected data"""
+    pt_scatter_plt.assert_xydata(pd_df, xcol="A", ycol="B", points_only=True)
+    plt.close()
+
+
+def test_assert_xydata_changed_data_points_only(pt_scatter_plt, pd_df):
+    """assert_xydata should fail when we change the data"""
+    pd_df["B"][1] += 5
+    with pytest.raises(AssertionError, match="Incorrect data values"):
+        pt_scatter_plt.assert_xydata(
+            pd_df, xcol="A", ycol="B", points_only=True
+        )
+    plt.close()
+
+
+'''
+def test_assert_xydata_timeseries(pt_time_line_plt, pd_df_timeseries):
+    """Commenting this out for now as this requires a time series data object
+    this is failing because the time data needs to be in seconds like how
+    mpl saves it. """
+    pt_time_line_plt.assert_xydata(pd_df_timeseries, xcol='time', ycol='A', xtime=True)
+'''
+
+
+def test_assert_xydata_xlabel(pt_bar_plt, pd_df):
+    "Tests the xlabels flag on xydata"
+    pd_df["A"] = pd_df["A"].apply(str)
+    pt_bar_plt.assert_xydata(pd_df, xcol="A", ycol="B", xlabels=True)
+    plt.close()
+
+
+def test_assert_xydata_xlabel_fails(pt_bar_plt, pd_df):
+    "Tests the xlabels flag on xydata"
+    pd_df["A"] = pd_df["A"].apply(str)
+    pd_df.iloc[1, 0] = "this ain't it cheif"
+    with pytest.raises(AssertionError, match="Incorrect data values"):
+        pt_bar_plt.assert_xydata(pd_df, xcol="A", ycol="B", xlabels=True)
+    plt.close()

--- a/matplotcheck/tests/test_base_data.py
+++ b/matplotcheck/tests/test_base_data.py
@@ -56,15 +56,6 @@ def test_assert_xydata_changed_data_points_only(pt_scatter_plt, pd_df):
     plt.close()
 
 
-'''
-def test_assert_xydata_timeseries(pt_time_line_plt, pd_df_timeseries):
-    """Commenting this out for now as this requires a time series data object
-    this is failing because the time data needs to be in seconds like how
-    mpl saves it. """
-    pt_time_line_plt.assert_xydata(pd_df_timeseries, xcol='time', ycol='A', xtime=True)
-'''
-
-
 def test_assert_xydata_xlabel(pt_bar_plt, pd_df):
     "Tests the xlabels flag on xydata"
     pd_df["A"] = pd_df["A"].apply(str)

--- a/matplotcheck/tests/test_base_data.py
+++ b/matplotcheck/tests/test_base_data.py
@@ -15,7 +15,8 @@ def test_assert_xydata_scatter(pt_scatter_plt, pd_df):
 
 
 def test_assert_xydata_tolerance(pt_scatter_plt, pd_df):
-    """Checks that slightly altered data still passes with an appropriate tolerance"""
+    """Checks that slightly altered data still passes with an appropriate
+    tolerance"""
     for i in range(len(pd_df["A"])):
         pd_df["A"][i] = pd_df["A"][i] + (np.floor(pd_df["A"][i] * 0.25))
         pd_df["B"][i] = pd_df["B"][i] + (np.floor(pd_df["B"][i] * 0.25))

--- a/matplotcheck/tests/test_base_data.py
+++ b/matplotcheck/tests/test_base_data.py
@@ -78,3 +78,9 @@ def test_assert_xydata_xlabel_fails(pt_bar_plt, pd_df):
     with pytest.raises(AssertionError, match="Incorrect data values"):
         pt_bar_plt.assert_xydata(pd_df, xcol="A", ycol="B", xlabels=True)
     plt.close()
+
+
+def test_assert_xydata_expected_none(pt_scatter_plt):
+    "Tests that assert_xydata passes when xy_expected is None"
+    pt_scatter_plt.assert_xydata(None)
+    plt.close()

--- a/matplotcheck/tests/test_base_titles_captions.py
+++ b/matplotcheck/tests/test_base_titles_captions.py
@@ -6,6 +6,14 @@ import matplotlib.pyplot as plt
 """ TITLE TESTS """
 
 
+def test_correct_title(pt_line_plt):
+    """Check that the correct plot title is grabbed from the axis object.
+    Note that get_titles maintains case."""
+
+    assert "Plot Title" in pt_line_plt.get_titles()[1]
+    plt.close()
+
+
 def test_get_titles(pt_line_plt):
     """Check that the correct plot title is grabbed from the axis object.
     Note that get_titles maintains case."""

--- a/matplotcheck/tests/test_ts_data.py
+++ b/matplotcheck/tests/test_ts_data.py
@@ -1,0 +1,9 @@
+import pytest
+
+'''
+def test_assert_xydata_timeseries(pt_time_line_plt, pd_df_timeseries):
+    """Commenting this out for now as this requires a time series data object
+    this is failing because the time data needs to be in seconds like how
+    mpl saves it. """
+    pt_time_line_plt.assert_xydata(pd_df_timeseries, xcol='time', ycol='A', xtime=True)
+'''


### PR DESCRIPTION
This pull request does a number of things.

- Adds some tests for the base module, mostly for `assert_xydata()`, addressing issue #101 
- Renames tests that shared names with other tests, causing only one to be defined and run. This addresses issue #101 
- Refactors `assert_xydata()` for clarity
- Moves the test `test_correct_title()` to test_base_titles_captions.py, addressing issue #115 
- Moves all the tests for `assert_xydata()` to test_base_data.py, addressing issue #114 