### PR TITLE
Fix to deal with pytest ValueError

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 Unreleased
 ----------
 
+- Added .buffer(0) to the multipolygons in pytest to account for GeoPandas update (@nkorinek, #401)
+
 0.1.4
 ----------
 

--- a/matplotcheck/tests/test_polygons.py
+++ b/matplotcheck/tests/test_polygons.py
@@ -21,7 +21,7 @@ def multi_polygon_gdf(basic_polygon):
     poly_a = Polygon([(3, 5), (2, 3.25), (5.25, 6), (2.25, 2), (2, 2)])
     gdf = gpd.GeoDataFrame(
         [1, 2],
-        geometry=[poly_a, basic_polygon],
+        geometry=[poly_a.buffer(0), basic_polygon.buffer(0)],
         crs="epsg:4326",
     )
     multi_gdf = gpd.GeoDataFrame(


### PR DESCRIPTION
A PR to update pre-commit was passing all tests in the PR. However, once merged, it came up with fails in pytest. I'm not sure why, but updating pre-commit broke how we make a multipolygon. I found a fairly simple fix online (adding a buffer of 0 gets rid of the conflicts without modifying the data). This is the fix and should pass all tests.